### PR TITLE
Add more tests to initial editor state

### DIFF
--- a/editor/initial_code/js_node
+++ b/editor/initial_code/js_node
@@ -12,5 +12,7 @@ var assert = require('assert');
 if (!global.is_checking) {
     assert.equal(longRepeat('sdsffffse'), 4, "First")
     assert.equal(longRepeat('ddvvrwwwrggg'), 3, "Second")
+    assert.equal(longRepeat('abababaab'), 2, "Third")
+    assert.equal(longRepeat(''), 0, "Empty")
     console.log('"Run" is good. How is "Check"?');
 }

--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -9,4 +9,6 @@ if __name__ == '__main__':
     #These "asserts" using only for self-checking and not necessary for auto-testing
     assert long_repeat('sdsffffse') == 4, "First"
     assert long_repeat('ddvvrwwwrggg') == 3, "Second"
+    assert long_repeat('abababaab') == 2, "Third"
+    assert long_repeat('') == 0, "Empty"
     print('"Run" is good. How is "Check"?')


### PR DESCRIPTION
Added two tests from the Extra category to the initial editor state. The original two were not testing whether we are not just returning most frequent letter count. Also added the empty string test, since it is a special case that must be handled correctly.